### PR TITLE
Set progressive encoding for larger images, baseline for small ones

### DIFF
--- a/lib/immagine/image_processor.rb
+++ b/lib/immagine/image_processor.rb
@@ -90,7 +90,7 @@ module Immagine
 
     def constrain_width!(width)
       if img.columns <= width
-        serve_image
+        img
       else
         resize_image_by_width!(width)
       end
@@ -98,7 +98,7 @@ module Immagine
 
     def constrain_height!(height)
       if img.rows <= height
-        serve_image
+        img
       else
         resize_image_by_height!(height)
       end
@@ -127,7 +127,7 @@ module Immagine
 
     def resize_relative_to_original!
       if img.columns <= 300
-        serve_image
+        img
       elsif img.rows <= 1050
         resize_image_by_width!(300)
       else
@@ -167,12 +167,6 @@ module Immagine
 
     def resize!(scale_factor)
       img.resize!(scale_factor)
-      serve_image
-    end
-
-    def serve_image
-      img.compression = Magick::JPEGCompression if img.format == 'JPEG'
-      img.interlace   = (img.columns * img.rows <= 100 * 100) ? Magick::NoInterlace : Magick::PlaneInterlace
       img
     end
 

--- a/lib/immagine/image_processor_driver.rb
+++ b/lib/immagine/image_processor_driver.rb
@@ -45,7 +45,10 @@ module Immagine
 
       img.strip!
 
-      blob = img.to_blob { self.quality = quality }
+      blob = img.to_blob do
+        self.quality   = quality
+        self.interlace = (img.columns * img.rows <= 100 * 100) ? Magick::NoInterlace : Magick::PlaneInterlace
+      end
       mime = img.mime_type
 
       [blob, mime]

--- a/spec/immagine/image_processor_spec.rb
+++ b/spec/immagine/image_processor_spec.rb
@@ -126,27 +126,5 @@ module Immagine
         end
       end
     end
-
-    describe 'Properties of produces images' do
-      describe 'when the format is JPEG' do
-        it 'uses JPEGCompression' do
-          img = processor.constrain_width!(100)
-
-          expect(img.compression).to eq(Magick::JPEGCompression)
-        end
-      end
-
-      it 'uses baseline encoding for small images' do
-        img = processor.resize_by_max!(20)
-
-        expect(img.interlace).to eq(Magick::NoInterlace)
-      end
-
-      it 'uses progressive encoding for bigger images' do
-        img = processor.resize_by_max!(600)
-
-        expect(img.interlace).to eq(Magick::PlaneInterlace)
-      end
-    end
   end
 end

--- a/spec/immagine/service_spec.rb
+++ b/spec/immagine/service_spec.rb
@@ -431,4 +431,23 @@ describe Immagine::Service do
       end
     end
   end
+
+  describe 'image encoding' do
+    # http://en.wikipedia.org/wiki/JPEG
+    # SOF2 [255, 194] = Start Of Frame (Progressive DCT)
+
+    it 'uses progressive encoding for large images' do
+      get '/live/images/m685/kitten.jpg'
+
+      expect(last_response).to be_ok
+      expect(last_response.body.bytes.join(',')).to include('255,194')
+    end
+
+    it 'uses baseline encoding for thumbnails' do
+      get '/live/images/w100h100/kitten.jpg'
+
+      expect(last_response).to be_ok
+      expect(last_response.body.bytes.join(',')).to_not include('255,194')
+    end
+  end
 end


### PR DESCRIPTION
Removed setting img.compression since as far as I can tell this is handled correctly by default in rmagick (file sizes didn't change when I removed it)
