### PR TITLE
Allows the quality to be set via the url

### DIFF
--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -5,6 +5,7 @@ format_whitelist:
   - w450      # At a glance popups
   - w926      # Full size figures
   - m685      # Article figures
+  - q10       # Example low quality
   - rel       # Illustrations
 
 source_folder: ./test-data/src

--- a/lib/immagine/format_processor.rb
+++ b/lib/immagine/format_processor.rb
@@ -4,8 +4,6 @@ module Immagine
 
     attr_reader :format_string
 
-    # TODO: make quality part of this option
-
     REGEX = {
       height:   /h(\d+)/,
       width:    /w(\d+)/,
@@ -13,7 +11,8 @@ module Immagine
       relative: /rel/,
       crop:     /c([A-Z]{1,2})-([\d]+)-([\d]+)-?([\d\.]+)?/,
       blur:     /b([\d\.]+)-?([\d\.]+)?/,
-      overlay:  /ov([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|dominant)?-?(\d{1,2})?/
+      overlay:  /ov([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|dominant)?-?(\d{1,2})?/,
+      quality:  /q(\d+)/
     }.freeze
 
     def initialize(format_string)
@@ -98,6 +97,10 @@ module Immagine
       match.to_i if match
     end
 
+    memoize def quality
+      extract_first_integer(:quality)
+    end
+
     private
 
     def valid_for_relative?
@@ -109,7 +112,7 @@ module Immagine
     end
 
     def valid_for_else?
-      height || width || crop? || blur? || overlay?
+      height || width || crop? || blur? || overlay? || quality
     end
 
     def extract_first_integer(regex_key)

--- a/lib/immagine/image_processor_driver.rb
+++ b/lib/immagine/image_processor_driver.rb
@@ -1,12 +1,11 @@
 module Immagine
   class ImageProcessorDriver
-    attr_reader :image_processor, :format_processor, :conversion_format, :quality
+    attr_reader :image_processor, :format_processor, :conversion_format
 
-    def initialize(image_processor, format_processor, conversion_format, quality)
+    def initialize(image_processor, format_processor, conversion_format)
       @image_processor   = image_processor
       @format_processor  = format_processor
       @conversion_format = conversion_format
-      @quality           = quality
     end
 
     def process
@@ -45,9 +44,10 @@ module Immagine
       # CONVERT
       image_processor.convert_format!(conversion_format) if conversion_format
 
-      img         = image_processor.img
-      img_quality = quality
+      # QUALITY
+      img_quality = format_processor.quality.to_i || 85
 
+      img = image_processor.img
       img.strip!
 
       blob = img.to_blob do

--- a/lib/immagine/image_processor_driver.rb
+++ b/lib/immagine/image_processor_driver.rb
@@ -8,6 +8,8 @@ module Immagine
       @conversion_format = conversion_format
     end
 
+    DEFAULT_QUALITY = 85
+
     def process
       # OVERLAY
       image_processor.overlay!(format_processor.overlay_color, format_processor.overlay_opacity) if format_processor.overlay?
@@ -45,7 +47,7 @@ module Immagine
       image_processor.convert_format!(conversion_format) if conversion_format
 
       # QUALITY
-      img_quality = format_processor.quality || 85
+      img_quality = format_processor.quality || DEFAULT_QUALITY
 
       img = image_processor.img
       img.strip!

--- a/lib/immagine/image_processor_driver.rb
+++ b/lib/immagine/image_processor_driver.rb
@@ -45,7 +45,7 @@ module Immagine
       image_processor.convert_format!(conversion_format) if conversion_format
 
       # QUALITY
-      img_quality = format_processor.quality.to_i || 85
+      img_quality = format_processor.quality || 85
 
       img = image_processor.img
       img.strip!

--- a/lib/immagine/service.rb
+++ b/lib/immagine/service.rb
@@ -5,7 +5,6 @@ require 'fileutils'
 
 module Immagine
   class Service < Sinatra::Base
-    DEFAULT_IMAGE_QUALITY = 85
     DEFAULT_EXPIRES       = 30 * 24 * 60 * 60 # 30 days in seconds
     ALLOWED_CONVERSION_FORMATS = %w(jpg png).freeze
 
@@ -204,8 +203,7 @@ module Immagine
 
     def generate_image(format_code, source_file, convert_to: nil)
       image_blob, mime = statsd.time('asset_resize') do
-        quality = Integer(request.env['HTTP_X_IMAGE_QUALITY'] || DEFAULT_IMAGE_QUALITY)
-        process_image(source_file, format_code, quality, convert_to)
+        process_image(source_file, format_code, convert_to)
       end
 
       # content type
@@ -214,13 +212,13 @@ module Immagine
       image_blob
     end
 
-    def process_image(path, format, quality, convert_to)
+    def process_image(path, format, convert_to)
       image_proc  = image_processor(path)
       format_proc = format_processor(format)
 
       raise "Unsupported format: '#{format}'" unless format_proc.valid?
 
-      ImageProcessorDriver.new(image_proc, format_proc, convert_to, quality).process
+      ImageProcessorDriver.new(image_proc, format_proc, convert_to).process
     end
 
     def process_video(source_file, output_file)

--- a/spec/immagine/format_processor_spec.rb
+++ b/spec/immagine/format_processor_spec.rb
@@ -14,6 +14,7 @@ describe Immagine::FormatProcessor do
 
     context 'Good formats' do
       %w(
+        q50
         rel
         relb2
         m500
@@ -31,6 +32,7 @@ describe Immagine::FormatProcessor do
         h100
         w100
         h100w100
+        h100w100q50
         ov
         ovdominant
         oveee
@@ -58,6 +60,43 @@ describe Immagine::FormatProcessor do
           it { expect(described_class.new(code)).to_not be_valid }
         end
       end
+    end
+  end
+
+  context 'qXX' do
+    let(:format) { "q#{quality}" }
+    let(:quality) { 50 }
+
+    describe '#max' do
+      it { expect(subject.max).to be_nil }
+    end
+
+    describe '#height' do
+      it { expect(subject.height).to be_nil }
+    end
+
+    describe '#width' do
+      it { expect(subject.width).to be_nil }
+    end
+
+    describe '#relative?' do
+      it { expect(subject.relative?).to be_falsey }
+    end
+
+    describe '#crop?' do
+      it { expect(subject.crop?).to be_falsey }
+    end
+
+    describe '#blur?' do
+      it { expect(subject.blur?).to be_falsey }
+    end
+
+    describe '#overlay?' do
+      it { expect(subject.overlay?).to be_falsey }
+    end
+
+    describe '#quality' do
+      it { expect(subject.quality).to eq(quality) }
     end
   end
 
@@ -90,6 +129,10 @@ describe Immagine::FormatProcessor do
 
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
+    end
+    
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
     end
   end
 
@@ -124,6 +167,10 @@ describe Immagine::FormatProcessor do
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
     end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
+    end
   end
 
   context 'wXXX' do
@@ -156,6 +203,10 @@ describe Immagine::FormatProcessor do
 
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
+    end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
     end
   end
 
@@ -199,6 +250,10 @@ describe Immagine::FormatProcessor do
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
     end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
+    end
   end
 
   context 'ovXX-XX' do
@@ -228,6 +283,10 @@ describe Immagine::FormatProcessor do
 
     describe '#blur?' do
       it { expect(subject.blur?).to be_falsey }
+    end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
     end
 
     describe '#overlay?' do
@@ -357,8 +416,50 @@ describe Immagine::FormatProcessor do
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
     end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
+    end
   end
 
+  context 'hXXXwXXXqXX' do
+    let(:format)  { "h#{height}w#{width}q#{quality}" }
+    let(:height)  { 200 }
+    let(:width)   { 200 }
+    let(:quality) { 50 }
+
+    describe '#max' do
+      it { expect(subject.max).to be_nil }
+    end
+
+    describe '#height' do
+      it { expect(subject.height).to eq(height) }
+    end
+
+    describe '#width' do
+      it { expect(subject.width).to eq(width) }
+    end
+
+    describe '#relative?' do
+      it { expect(subject.relative?).to be_falsey }
+    end
+
+    describe '#crop?' do
+      it { expect(subject.crop?).to be_falsey }
+    end
+
+    describe '#blur?' do
+      it { expect(subject.blur?).to be_falsey }
+    end
+
+    describe '#overlay?' do
+      it { expect(subject.overlay?).to be_falsey }
+    end
+
+    describe '#quality' do
+      it { expect(subject.quality).to eq(quality) }
+    end
+  end
   context 'cXX-XXX-XXX-XX' do
     let(:format)        { "c#{gravity}-#{height}-#{width}-#{resize_ratio}" }
     let(:height)        { 200 }
@@ -409,6 +510,10 @@ describe Immagine::FormatProcessor do
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
     end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
+    end
   end
 
   context 'bXXhXXXwXXX' do
@@ -451,6 +556,10 @@ describe Immagine::FormatProcessor do
 
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
+    end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
     end
   end
 
@@ -512,6 +621,10 @@ describe Immagine::FormatProcessor do
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
     end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
+    end
   end
 
   context 'bXXmXXX' do
@@ -553,6 +666,10 @@ describe Immagine::FormatProcessor do
 
     describe '#overlay?' do
       it { expect(subject.overlay?).to be_falsey }
+    end
+
+    describe '#quality' do
+      it { expect(subject.quality).to be_nil }
     end
   end
 end

--- a/spec/immagine/service_spec.rb
+++ b/spec/immagine/service_spec.rb
@@ -423,7 +423,7 @@ describe Immagine::Service do
         file_types.each do |to_format|
           it "converts to #{to_format}" do
             expect(Immagine::ImageProcessorDriver).to receive(:new).with(
-              anything, anything, to_format.downcase.to_sym, anything
+              anything, anything, to_format.downcase.to_sym
             ).and_return(driver)
 
             get "/live/images/w100h100/kitten.jpg/convert/kitten.#{to_format}"

--- a/spec/immagine/service_spec.rb
+++ b/spec/immagine/service_spec.rb
@@ -396,41 +396,6 @@ describe Immagine::Service do
       end
     end
 
-    context 'Image Quality' do
-      let(:format_code) { Immagine.settings.lookup('format_whitelist').sample }
-      let(:img_source)  { '/live/images/kitten.jpg' }
-      let(:file_path)   { File.join(Immagine.settings.lookup('source_folder'), img_source) }
-
-      context 'no custom headers' do
-        it 'uses the default image quality setting' do
-          expect_any_instance_of(Immagine::Service)
-            .to receive(:process_image)
-            .with(file_path, format_code, Immagine::Service::DEFAULT_IMAGE_QUALITY, nil)
-            .and_call_original
-
-          get "/live/images/#{format_code}/kitten.jpg"
-
-          expect(last_response).to be_ok
-        end
-      end
-
-      context 'with a X-Image-Quality HTTP header' do
-        let(:quality) { Immagine::Service::DEFAULT_IMAGE_QUALITY - 20 }
-
-        it 'uses the passed quality setting' do
-          expect_any_instance_of(Immagine::Service)
-            .to receive(:process_image)
-            .with(file_path, format_code, quality, nil)
-            .and_call_original
-
-          header 'X_IMAGE_QUALITY', quality
-          get "/live/images/#{format_code}/kitten.jpg"
-
-          expect(last_response).to be_ok
-        end
-      end
-    end
-
     context 'Image Encoding for JPEGs' do
       # http://en.wikipedia.org/wiki/JPEG
       # SOF2 [255, 194] = Start Of Frame (Progressive DCT)


### PR DESCRIPTION
This would now allow the quality of the image to be set via the url. The
quality parameter can be set between 0 - 100.

The url will look like the following

`/{path}/q10/{file_name}`