### PR TITLE
Issue #55 - handle failures if FFMPEG is not installed

### DIFF
--- a/lib/immagine/service.rb
+++ b/lib/immagine/service.rb
@@ -93,8 +93,8 @@ module Immagine
 
         generate_image(format_code, source_file)
       rescue Errno::ENOENT
-        log_error('404, video processing not supported.')
-        raise Sinatra::NotFound
+        log_error('412, video processing not available on this server.')
+        halt 412
       ensure
         FileUtils.rm_rf(File.join(source_folder, 'tmp', filename))
       end

--- a/lib/immagine/service.rb
+++ b/lib/immagine/service.rb
@@ -69,7 +69,7 @@ module Immagine
       filename   = basename.sub(/#{file_ext}$/, '')
 
       if VideoProcessor::VIDEO_FORMATS.include?(file_ext)
-        generate_video_screenshot(dir, basename, filename)
+        generate_video_screenshot(format_code, source_file, dir, filename)
       else
         generate_image(format_code, source_file)
       end
@@ -81,8 +81,7 @@ module Immagine
       Immagine.settings.lookup('source_folder')
     end
 
-    def generate_video_screenshot(dir, basename, filename)
-      source_file = source_file_path(dir, basename)
+    def generate_video_screenshot(format_code, source_file, dir, filename)
       begin
         FileUtils.mkpath(File.join(source_folder, 'tmp', filename))
 
@@ -90,9 +89,12 @@ module Immagine
 
         process_video(source_file, output_file)
 
-        FileUtils.cp(output_file, File.join(source_folder, dir, "#{filename}.jpg"))
+        source_file = check_and_copy_screenshot(output_file, dir, filename)
 
-        source_file = File.join(source_folder, dir, "#{filename}.jpg")
+        generate_image(format_code, source_file)
+      rescue Errno::ENOENT
+        log_error('404, video processing not supported.')
+        raise Sinatra::NotFound
       ensure
         FileUtils.rm_rf(File.join(source_folder, 'tmp', filename))
       end
@@ -155,6 +157,11 @@ module Immagine
       set_cache_control_headers(request, dir)
       statsd.increment('serve_original_image')
       send_file(static_file)
+    end
+
+    def check_and_copy_screenshot(output_file, dir, filename)
+      FileUtils.cp(output_file, File.join(source_folder, dir, "#{filename}.jpg"))
+      File.join(source_folder, dir, "#{filename}.jpg")
     end
 
     def set_etag_and_cache_headers(dir, format_code, basename, source_file)
@@ -224,7 +231,9 @@ module Immagine
     end
 
     def process_video(source_file, output_file)
-      video_processor(source_file).screenshot(output_file)
+      video_proc = video_processor(source_file)
+
+      video_processor(source_file).screenshot(output_file) if video_proc.video
     end
 
     def image_processor(path)

--- a/lib/immagine/video_processor.rb
+++ b/lib/immagine/video_processor.rb
@@ -1,17 +1,21 @@
 module Immagine
   class VideoProcessor
-    attr_reader :video
+    attr_reader :source
 
     VIDEO_FORMATS = %w(.mov .flv .mp4 .avi .mpg .wmv).freeze
 
     def initialize(source)
-      @video = FFMPEG::Movie.new(source)
+      @source = source
+    end
+
+    def video
+      FFMPEG::Movie.new(source)
     rescue Errno::ENOENT => ex
       log_error("Video processing not supported - #{ex}")
+      return nil
     end
 
     def screenshot(output_path)
-      return nil unless video
       video.screenshot(output_path, seek_time: second)
     end
 

--- a/spec/immagine/service_spec.rb
+++ b/spec/immagine/service_spec.rb
@@ -506,14 +506,14 @@ describe Immagine::Service do
       let(:file_path)   { File.join(Immagine.settings.lookup('source_folder'), img_source) }
       let(:output_path) { File.join(Immagine.settings.lookup('source_folder'), 'tmp', filename, 'screenshot.jpg') }
 
-      it 'returns a 404' do
+      it 'returns a 412' do
         expect_any_instance_of(Immagine::Service)
           .to receive(:process_video)
           .with(file_path, output_path)
           .and_return(nil)
 
         get '/live/videos/w100h100/cat-vs-food.mp4'
-        expect(last_response.status).to eq(404)
+        expect(last_response.status).to eq(412)
       end
     end
   end


### PR DESCRIPTION
Fixes #55 

Add handling for errors if FFMPEG is not installed on a system - return a 412 and log error. 